### PR TITLE
Eliminate a potential crash in ResultFile

### DIFF
--- a/mzLib/Readers/ExternalResults/BaseClasses/ResultFile.cs
+++ b/mzLib/Readers/ExternalResults/BaseClasses/ResultFile.cs
@@ -12,14 +12,26 @@ namespace Readers
         #region Base Properties
         public string FilePath { get; set; }
 
-        private List<TResult> _results;
+        private List<TResult>? _results;
         public List<TResult> Results
         {
             get
             {
-                if (!_results.Any())
+                // if the results have already been read in or set
+                if (_results is not null) 
+                    return _results;
+
+                // if the results have not been read, and the file exists, read the results
+                if (File.Exists(FilePath)) 
                     LoadResults();
-                return _results;
+
+                // if the results have not been read, and the file does not exist, return a new collection
+                else 
+                   _results = [];
+
+                // added null ignoring operator as the LoadResults will set the _results field
+                // and thus there is no chance of the _result being null by the time of this return
+                return _results!;
             }
             set => _results = value;
         }
@@ -31,7 +43,7 @@ namespace Readers
         protected ResultFile(string filePath, Software software = Software.Unspecified)
         {
             FilePath = filePath;
-            _results = new List<TResult>();
+            _results = null;
             Software = software;
         }
 

--- a/mzLib/Readers/ExternalResults/ResultFiles/Ms1FeatureFile.cs
+++ b/mzLib/Readers/ExternalResults/ResultFiles/Ms1FeatureFile.cs
@@ -16,14 +16,17 @@ namespace Readers
         public Ms1FeatureFile(string filePath, Software deconSoftware = Software.Unspecified) : base(filePath,
             deconSoftware)
         {
-            using (var sr = new StreamReader(filePath))
-            {
-                string firstLine = sr.ReadLine() ?? "";
-                if (firstLine.Contains("\tApex_intensity\t") || firstLine.Contains("\tIntensity_Apex\t"))
-                    Software = Software.TopFD;
-                else
-                    Software = Software.FLASHDeconv;
-            }
+            if (File.Exists(filePath))
+                using (var sr = new StreamReader(filePath))
+                {
+                    string firstLine = sr.ReadLine() ?? "";
+                    if (firstLine.Contains("\tApex_intensity\t") || firstLine.Contains("\tIntensity_Apex\t"))
+                        Software = Software.TopFD;
+                    else
+                        Software = Software.FLASHDeconv;
+                }
+            else
+                Software = Software.Unspecified;
         }
 
         /// <summary>

--- a/mzLib/Test/FileReadingTests/TestResultFile.cs
+++ b/mzLib/Test/FileReadingTests/TestResultFile.cs
@@ -1,13 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Diagnostics.CodeAnalysis;
 using NUnit.Framework;
 using NUnit.Framework.Legacy;
-using pepXML.Generated;
 using Readers;
 
 namespace Test.FileReadingTests

--- a/mzLib/Test/FileReadingTests/TestResultFile.cs
+++ b/mzLib/Test/FileReadingTests/TestResultFile.cs
@@ -1,10 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
+using pepXML.Generated;
 using Readers;
 
 namespace Test.FileReadingTests
@@ -63,6 +66,37 @@ namespace Test.FileReadingTests
             {
                 Assert.That(feature.GetType() == typeof(Ms1Feature));
             }
+        }
+
+        [Test]
+        public static void TestResultAutoLoading_ExistingFile()
+        {
+            string filePath = @"FileReadingTests\ExternalFileTypes\Ms1Feature_TopFDv1.6.2_ms1.feature";
+            Ms1FeatureFile ms1FeatureFile = new Ms1FeatureFile(filePath);
+
+            // Automatically reading an existing file should not throw an exception
+            var features = ms1FeatureFile.Results;
+
+            // A second call should return the exact same list by reference
+            var features2 = ms1FeatureFile.Results;
+            CollectionAssert.AreEqual(features, features2);
+        }
+
+        [Test]
+        public static void TestResultAutoLoading_NewFile()
+        {
+            string filePath = @"FileReadingTests\ExternalFileTypes\NotARealFile_ms1.feature";
+            Ms1FeatureFile ms1FeatureFile = new Ms1FeatureFile(filePath);
+
+            // Automatically reading an existing file should not throw an exception
+            var features = ms1FeatureFile.Results;
+
+            // The result should be an empty collection
+            CollectionAssert.IsEmpty(features);
+
+            // A second call should return the exact same list by reference
+            var features2 = ms1FeatureFile.Results;
+            CollectionAssert.AreEqual(features, features2);
         }
     }
 }


### PR DESCRIPTION
#### PR Classification
Code enhancement to improve null handling and file existence checks in the readers base ResultFile class.

### PR Motivation
If the Results is not populated at time of calling, the LoadResults method is called.  This would lead to a FileNotFoundException when the file does not exist.

#### PR Summary
Improved null handling in `ResultFile` and added file existence checks in `Ms1FeatureFile`, along with new tests.
- `ResultFile.cs`: Made `_results` nullable, updated `Results` property logic, and added comments.
- `Ms1FeatureFile.cs`: Added file existence check and set `Software` property to `Unspecified` if file is missing.
- `TestResultFile.cs`: Removed unnecessary `using` directives and added tests for file existence scenarios.
