### PR TITLE
Zhuoxin Averaging Tweak

### DIFF
--- a/mzLib/SpectralAveraging/Algorithms/SpectraAveraging.cs
+++ b/mzLib/SpectralAveraging/Algorithms/SpectraAveraging.cs
@@ -56,7 +56,7 @@ public static class SpectraAveraging
         var bins = GetBins(xArrays, yArrays, parameters.BinSize);
 
         // get weights
-        var weights = SpectralWeighting.CalculateSpectraWeights(xArrays, yArrays, parameters.SpectralWeightingType, parameters.MzStep);
+        var weights = SpectralWeighting.CalculateSpectraWeights(xArrays, yArrays, parameters.SpectralWeightingType);
 
         var binWeights = new Dictionary<int, Dictionary<int, double>>();
         if (parameters.SpectralWeightingType == SpectraWeightingType.LocalizedTicValue)

--- a/mzLib/SpectralAveraging/Algorithms/SpectralWeighting.cs
+++ b/mzLib/SpectralAveraging/Algorithms/SpectralWeighting.cs
@@ -23,7 +23,7 @@ public static class SpectralWeighting
     /// <returns>Dictionary of weights where the key is the spectra index and the value is the weight</returns>
     /// <exception cref="MzLibException"></exception>
     public static Dictionary<int, double> CalculateSpectraWeights(double[][] xArrays, double[][] yArrays,
-        SpectraWeightingType spectraWeightingType, int mzStep = 5)
+        SpectraWeightingType spectraWeightingType)
     {
         switch (spectraWeightingType)
         {
@@ -61,7 +61,7 @@ public static class SpectralWeighting
                 .Select(p => p.Select(x => x.Mz).ToArray())
                 .ToArray();
 
-            var weights = CalculateSpectraWeights(xArray, yArray, weightingType, mzStep);
+            var weights = CalculateSpectraWeights(xArray, yArray, weightingType);
             binWeights.Add(-1, weights);
             return binWeights;
         }

--- a/mzLib/SpectralAveraging/DataStructures/Enums/SpectraWeightingType.cs
+++ b/mzLib/SpectralAveraging/DataStructures/Enums/SpectraWeightingType.cs
@@ -4,5 +4,6 @@ public enum SpectraWeightingType
 {
     WeightEvenly,
     MrsNoiseEstimation,
-    TicValue
+    TicValue,
+    LocalizedTicValue,
 }

--- a/mzLib/SpectralAveraging/Util/SpectralAveragingParameters.cs
+++ b/mzLib/SpectralAveraging/Util/SpectralAveragingParameters.cs
@@ -39,7 +39,7 @@ public class SpectralAveragingParameters
         SpectraFileAveragingType specAveragingType = SpectraFileAveragingType.AverageAll,
         OutputType outputType = OutputType.MzML, int numToAverage = 5, int overlap = 2,
         double percentile = 0.1, double minSigma = 1.5, double maxSigma = 1.5, double binSize = 0.01,
-        int maxThreads = 1, int localizedTicPartitions = 30)
+        int maxThreads = 1, int mzStep = 30)
     {
         OutlierRejectionType = outlierRejectionType;
         SpectralWeightingType = spectraWeighingType;
@@ -54,7 +54,7 @@ public class SpectralAveragingParameters
         MaxSigmaValue = maxSigma;
         BinSize = binSize;
         MaxThreadsToUsePerFile = maxThreads;
-        MzStep = localizedTicPartitions;
+        MzStep = mzStep;
     }
 
     /// <summary>

--- a/mzLib/SpectralAveraging/Util/SpectralAveragingParameters.cs
+++ b/mzLib/SpectralAveraging/Util/SpectralAveragingParameters.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
@@ -21,6 +20,7 @@ public class SpectralAveragingParameters
     public int NumberOfScansToAverage { get; set; }
     public int ScanOverlap { get; set; }
     public int MaxThreadsToUsePerFile { get; set; } = 1;
+    public int MzStep { get; set; }
 
     #endregion
 
@@ -39,7 +39,7 @@ public class SpectralAveragingParameters
         SpectraFileAveragingType specAveragingType = SpectraFileAveragingType.AverageAll,
         OutputType outputType = OutputType.MzML, int numToAverage = 5, int overlap = 2,
         double percentile = 0.1, double minSigma = 1.5, double maxSigma = 1.5, double binSize = 0.01,
-        int maxThreads = 1)
+        int maxThreads = 1, int localizedTicPartitions = 30)
     {
         OutlierRejectionType = outlierRejectionType;
         SpectralWeightingType = spectraWeighingType;
@@ -54,6 +54,7 @@ public class SpectralAveragingParameters
         MaxSigmaValue = maxSigma;
         BinSize = binSize;
         MaxThreadsToUsePerFile = maxThreads;
+        MzStep = localizedTicPartitions;
     }
 
     /// <summary>
@@ -74,8 +75,8 @@ public class SpectralAveragingParameters
         MaxSigmaValue = 1.5;
         BinSize = 0.01;
         MaxThreadsToUsePerFile = 1;
+        MzStep = 20;
     }
-
 
     /// <summary>
     /// Generates an IEnumerable of Spectral Averaging Parameters with all valid combinations of parameters
@@ -163,8 +164,6 @@ public class SpectralAveragingParameters
         }
         return averagingParams;
     }
-
-
 
     /// <summary>
     ///     Override for the ToString method that can be used for file output naming

--- a/mzLib/Test/AveragingTests/TestAveragingSpectraWriteFile.cs
+++ b/mzLib/Test/AveragingTests/TestAveragingSpectraWriteFile.cs
@@ -55,10 +55,52 @@ namespace Test.AveragingTests
         }
 
         [Test]
+        public static void Temp()
+        {
+            string inputPath = @"B:\Users\Zhuoxin\ISD\ISD_240812\08-12-24_PEPPI_FractionD_orbiMS1_ISD60-80-100.mzML";
+            var dir = Path.GetDirectoryName(inputPath);
+            var dataFile = MsDataFileReader.GetDataFile(inputPath);
+
+            var relativeToTicsOutPath = "08-12-24_PEPPI_FractionD_orbiMS1_ISD60-80-100__relativeToTics.mzML";
+            var parameters = new SpectralAveragingParameters()
+            {
+                NormalizationType = NormalizationType.RelativeToTics,
+                SpectraFileAveragingType = SpectraFileAveragingType.AverageDdaScans,
+                SpectralWeightingType = SpectraWeightingType.LocalizedTicValue,
+                BinSize = 0.01,
+                MzStep = 10,
+                OutlierRejectionType = OutlierRejectionType.SigmaClipping,
+                NumberOfScansToAverage = 5
+            };
+
+            var averagedSpectra = SpectraFileAveraging.AverageSpectraFile(Scans, Parameters);
+            AveragedSpectraWriter.WriteAveragedScans(averagedSpectra, parameters, inputPath, dir, relativeToTicsOutPath);
+
+
+
+
+
+            var relativeIntensityOutPath = "08-12-24_PEPPI_FractionD_orbiMS1_ISD60-80-100__relativeIntensity.mzML";
+            var parameters2 = new SpectralAveragingParameters()
+            {
+                NormalizationType = NormalizationType.RelativeIntensity,
+                SpectraFileAveragingType = SpectraFileAveragingType.AverageDdaScans,
+                SpectralWeightingType = SpectraWeightingType.LocalizedTicValue,
+                BinSize = 0.01,
+                MzStep = 10,
+                OutlierRejectionType = OutlierRejectionType.SigmaClipping,
+            };
+            var averagedSpectra2 = SpectraFileAveraging.AverageSpectraFile(Scans, Parameters);
+            AveragedSpectraWriter.WriteAveragedScans(averagedSpectra2, parameters2, inputPath, dir, relativeIntensityOutPath);
+        }
+
+        [Test]
         public static void OutputAveragedSpectraAsMzMLTest()
         {
             // test that it outputs correctly
             Assert.That(Parameters.OutputType == OutputType.MzML);
+
+            Parameters.SpectralWeightingType = SpectraWeightingType.LocalizedTicValue;
             AveragedSpectraWriter.WriteAveragedScans(DdaCompositeSpectra, Parameters, SpectraPath);
             string averagedSpectraPath = Path.Combine(OutputDirectory,
                 Path.GetFileNameWithoutExtension(SpectraPath) + "-averaged.mzML");

--- a/mzLib/Test/AveragingTests/TestAveragingSpectraWriteFile.cs
+++ b/mzLib/Test/AveragingTests/TestAveragingSpectraWriteFile.cs
@@ -75,7 +75,7 @@ namespace Test.AveragingTests
                 ScanOverlap = 4,
             };
 
-            var averagedSpectra = SpectraFileAveraging.AverageSpectraFile(Scans, Parameters);
+            var averagedSpectra = SpectraFileAveraging.AverageSpectraFile(dataFile.Scans.ToList(), Parameters);
             AveragedSpectraWriter.WriteAveragedScans(averagedSpectra, parameters, inputPath, dir, relativeToTicsOutPath);
 
 
@@ -94,7 +94,7 @@ namespace Test.AveragingTests
                 NumberOfScansToAverage = 5,
                 ScanOverlap = 4,
             };
-            var averagedSpectra2 = SpectraFileAveraging.AverageSpectraFile(Scans, Parameters);
+            var averagedSpectra2 = SpectraFileAveraging.AverageSpectraFile(dataFile.Scans.ToList(), Parameters);
             AveragedSpectraWriter.WriteAveragedScans(averagedSpectra2, parameters2, inputPath, dir, relativeIntensityOutPath);
         }
 

--- a/mzLib/Test/AveragingTests/TestAveragingSpectraWriteFile.cs
+++ b/mzLib/Test/AveragingTests/TestAveragingSpectraWriteFile.cs
@@ -60,6 +60,7 @@ namespace Test.AveragingTests
             string inputPath = @"B:\Users\Zhuoxin\ISD\ISD_240812\08-12-24_PEPPI_FractionD_orbiMS1_ISD60-80-100.mzML";
             var dir = Path.GetDirectoryName(inputPath);
             var dataFile = MsDataFileReader.GetDataFile(inputPath);
+            dataFile.LoadAllStaticData();
 
             var relativeToTicsOutPath = "08-12-24_PEPPI_FractionD_orbiMS1_ISD60-80-100__relativeToTics.mzML";
             var parameters = new SpectralAveragingParameters()
@@ -70,7 +71,8 @@ namespace Test.AveragingTests
                 BinSize = 0.01,
                 MzStep = 10,
                 OutlierRejectionType = OutlierRejectionType.SigmaClipping,
-                NumberOfScansToAverage = 5
+                NumberOfScansToAverage = 5,
+                ScanOverlap = 4,
             };
 
             var averagedSpectra = SpectraFileAveraging.AverageSpectraFile(Scans, Parameters);
@@ -89,6 +91,8 @@ namespace Test.AveragingTests
                 BinSize = 0.01,
                 MzStep = 10,
                 OutlierRejectionType = OutlierRejectionType.SigmaClipping,
+                NumberOfScansToAverage = 5,
+                ScanOverlap = 4,
             };
             var averagedSpectra2 = SpectraFileAveraging.AverageSpectraFile(Scans, Parameters);
             AveragedSpectraWriter.WriteAveragedScans(averagedSpectra2, parameters2, inputPath, dir, relativeIntensityOutPath);

--- a/mzLib/Test/AveragingTests/TestSpectraFileAveraging.cs
+++ b/mzLib/Test/AveragingTests/TestSpectraFileAveraging.cs
@@ -367,6 +367,7 @@ namespace Test.AveragingTests
             var scansToAverage = typeof(TestSpectraFileAveraging).GetProperty(listPropertyName)?.GetValue(null) as List<MsDataScan>;
             SpectralAveragingParameters.SpectraFileAveragingType = SpectraFileAveragingType.AverageDdaScans;
             SpectralAveragingParameters.NumberOfScansToAverage = numScansToAverage;
+            SpectralAveragingParameters.SpectralWeightingType = SpectraWeightingType.LocalizedTicValue;
 
             int ms1Count = scansToAverage.Count(p => p.MsnOrder == 1);
             int ms2Count = scansToAverage.Count(p => p.MsnOrder == 2);


### PR DESCRIPTION
#### PR Classification
New feature: Added support for `LocalizedTicValue` weighting type in spectral averaging.

#### PR Summary
This pull request introduces the `LocalizedTicValue` weighting type and updates related methods and tests to support it.
- `SpectralWeighting`: Added `CalculateBinWeights` method and updated `CalculateSpectraWeights` to accept `mzStep` parameter.
- `SpectraAveraging`: Modified `AverageBin` method to use new bin weights for `LocalizedTicValue`.
- `SpectralAveragingParameters`: Added `MzStep` property and updated constructor.
- `TestAveragingSpectraWriteFile`: Added `Temp` test method for `LocalizedTicValue`.
- Updated existing tests to set `SpectralWeightingType` to `LocalizedTicValue`.
