### PR TITLE
Put those mods back on the termini

### DIFF
--- a/mzLib/Omics/Digestion/DigestionProduct.cs
+++ b/mzLib/Omics/Digestion/DigestionProduct.cs
@@ -110,13 +110,25 @@ namespace Omics.Digestion
                         //the modification is protease associated and is applied to the n-terminal cleaved residue, not at the beginning of the protein
                         if (ModificationLocalization.ModFits(mod, Parent.BaseSequence, 1, length, OneBasedStartResidue))
                         {
-                            if (mod.ModificationType == "Protease")
+                            if (mod.ModificationType == "Protease") // Protease N-terminal or 5' modification
                             {
                                 if (OneBasedStartResidue != 1)
                                     fixedModsOneIsNterminus[2] = mod;
                             }
+                            else if (OneBasedStartResidue == 1) // Modified BioPolymer Start Residue (e.g. Protein N-Terminal)
+                            {
+                                if (!fixedModsOneIsNterminus.TryAdd(1, mod)) // Check if a protein N-terminal mod is already present
+                                {
+                                    if (mod.LocationRestriction is "N-terminal." or "5'-terminal.") // Only overwrite if new mod is N-terminal, not peptide N-terminal
+                                    {
+                                        fixedModsOneIsNterminus[1] = mod;
+                                    }
+                                }
+                            }
                             else //Normal N-terminal peptide modification
+                            {
                                 fixedModsOneIsNterminus[1] = mod;
+                            }
                         }
                         break;
 
@@ -137,13 +149,25 @@ namespace Omics.Digestion
                         //the modification is protease associated and is applied to the c-terminal cleaved residue, not if it is at the end of the protein
                         if (ModificationLocalization.ModFits(mod, Parent.BaseSequence, length, length, OneBasedStartResidue + length - 1))
                         {
-                            if (mod.ModificationType == "Protease")
+                            if (mod.ModificationType == "Protease") // Protease N-terminal or 3' modification
                             {
                                 if (OneBasedEndResidue != Parent.Length)
                                     fixedModsOneIsNterminus[length + 1] = mod;
                             }
+                            else if (OneBasedEndResidue == Parent.Length) // Modified BioPolymer End Residue (e.g. Protein C-Terminal)
+                            {
+                                if (!fixedModsOneIsNterminus.TryAdd(length + 2, mod)) // Check if a protein C-terminal mod is already present
+                                {
+                                    if (mod.LocationRestriction is "C-terminal." or "3'-terminal.") // Only overwrite if new mod is C-terminal, not peptide C-terminal
+                                    {
+                                        fixedModsOneIsNterminus[length + 2] = mod;
+                                    }
+                                }
+                            }
                             else //Normal C-terminal peptide modification 
+                            {
                                 fixedModsOneIsNterminus[length + 2] = mod;
+                            }
                         }
                         break;
 

--- a/mzLib/Omics/Modifications/ModificationLocalization.cs
+++ b/mzLib/Omics/Modifications/ModificationLocalization.cs
@@ -31,18 +31,17 @@
             }
             switch (attemptToLocalize.LocationRestriction)
             {
+                    // Only the intact (undigested) terminus
                 case "N-terminal." when bioPolymerOneBasedIndex > 2:
-                case "Peptide N-terminal." when digestionProductOneBasedIndex > 1 || bioPolymerOneBasedIndex == 1:
-                case "C-terminal." when bioPolymerOneBasedIndex < sequence.Length:
-                case "Peptide C-terminal." when digestionProductOneBasedIndex < digestionProductLength || bioPolymerOneBasedIndex == sequence.Length:
                 case "5'-terminal." when bioPolymerOneBasedIndex > 2:
-                // first residue in oligo but not first in nucleic acid
-                case "Oligo 5'-terminal." when digestionProductOneBasedIndex > 1
-                                               || bioPolymerOneBasedIndex == 1:
+                case "C-terminal." when bioPolymerOneBasedIndex < sequence.Length:
                 case "3'-terminal." when bioPolymerOneBasedIndex < sequence.Length:
-                // not the last residue in oligo but not in nucleic acid
-                case "Oligo 3'-terminal." when digestionProductOneBasedIndex < digestionProductLength
-                                               || bioPolymerOneBasedIndex == sequence.Length:
+
+                    // All Digested Termini AND original undigested termini
+                case "Peptide N-terminal." when digestionProductOneBasedIndex > 1:
+                case "Oligo 5'-terminal." when digestionProductOneBasedIndex > 1:
+                case "Peptide C-terminal." when digestionProductOneBasedIndex < digestionProductLength:
+                case "Oligo 3'-terminal." when digestionProductOneBasedIndex < digestionProductLength:
                     return false;
 
                 default:

--- a/mzLib/Test/Transcriptomics/TestDigestion.cs
+++ b/mzLib/Test/Transcriptomics/TestDigestion.cs
@@ -381,8 +381,9 @@ namespace Test.Transcriptomics
             variableMods = new List<Modification> { oligoCyclicPhosphate };
             digestionProducts = rna.Digest(digestionParams, new List<Modification>(), variableMods)
                 .Select(p => (OligoWithSetMods)p).ToList();
-            Assert.That(digestionProducts.Count, Is.EqualTo(1));
+            Assert.That(digestionProducts.Count, Is.EqualTo(2));
             Assert.That(digestionProducts[0].FullSequence, Is.EqualTo("UAGUCGUUGAUAG"));
+            Assert.That(digestionProducts[1].FullSequence, Is.EqualTo("UAGUCGUUGAUAG[Digestion Termini:Cyclic Phosphate on X]"));
 
             // RNase T1 digestion, 3' terminal modification
             digestionParams = new RnaDigestionParams("RNase T1");
@@ -403,13 +404,13 @@ namespace Test.Transcriptomics
             variableMods = new List<Modification> { oligoCyclicPhosphate };
             digestionProducts = rna.Digest(digestionParams, new List<Modification>(), variableMods)
                 .Select(p => (OligoWithSetMods)p).ToList();
-            Assert.That(digestionProducts.Count, Is.EqualTo(7));
+            Assert.That(digestionProducts.Count, Is.EqualTo(8));
             expected = new List<string>()
             {
                 "UAG", "UAG[Digestion Termini:Cyclic Phosphate on X]",
                 "UCG", "UCG[Digestion Termini:Cyclic Phosphate on X]",
                 "UUG", "UUG[Digestion Termini:Cyclic Phosphate on X]",
-                "AUAG",
+                "AUAG","AUAG[Digestion Termini:Cyclic Phosphate on X]"
             };
 
             for (int i = 0; i < expected.Count; i++)
@@ -431,7 +432,7 @@ namespace Test.Transcriptomics
                 out errors).First();
             Assert.That(!errors.Any());
 
-            // top-down digestion, 5' terminal modification
+            // top-down digestion, 5' terminal modification, expect two products
             var variableMods = new List<Modification> { nucleicAcidLargeMod };
             var digestionParams = new RnaDigestionParams("top-down");
             var digestionProducts = rna.Digest(digestionParams, new List<Modification>(), variableMods)
@@ -440,12 +441,13 @@ namespace Test.Transcriptomics
             Assert.That(digestionProducts[0].FullSequence, Is.EqualTo("UAGUCGUUGAUAG"));
             Assert.That(digestionProducts[1].FullSequence, Is.EqualTo("[Standard:Pfizer 5'-Cap on X]UAGUCGUUGAUAG"));
 
-            // top-down digestion, 5' oligo terminal modification
+            // top-down digestion, 5' oligo terminal modification, expect two products
             variableMods = new List<Modification> { oligoLargeMod };
             digestionProducts = rna.Digest(digestionParams, new List<Modification>(), variableMods)
                 .Select(p => (OligoWithSetMods)p).ToList();
-            Assert.That(digestionProducts.Count, Is.EqualTo(1));
+            Assert.That(digestionProducts.Count, Is.EqualTo(2));
             Assert.That(digestionProducts[0].FullSequence, Is.EqualTo("UAGUCGUUGAUAG"));
+            Assert.That(digestionProducts[1].FullSequence, Is.EqualTo("[Standard:Pfizer 5'-Cap on X]UAGUCGUUGAUAG"));
 
             // RNase T1 digestion, 5' terminal modification
             digestionParams = new RnaDigestionParams("RNase T1");
@@ -466,10 +468,10 @@ namespace Test.Transcriptomics
             variableMods = new List<Modification> { oligoLargeMod };
             digestionProducts = rna.Digest(digestionParams, new List<Modification>(), variableMods)
                 .Select(p => (OligoWithSetMods)p).ToList();
-            Assert.That(digestionProducts.Count, Is.EqualTo(7));
+            Assert.That(digestionProducts.Count, Is.EqualTo(8));
             expected = new List<string>()
             {
-                "UAG",
+                "UAG", "[Standard:Pfizer 5'-Cap on X]UAG",
                 "UCG", "[Standard:Pfizer 5'-Cap on X]UCG",
                 "UUG", "[Standard:Pfizer 5'-Cap on X]UUG",
                 "AUAG", "[Standard:Pfizer 5'-Cap on X]AUAG"


### PR DESCRIPTION
My last PR made an incorrect assumption: modification localization restriction "peptide N-terminal" is meant to refer to ANY N-term, not just those that are generated during digestion. 

In the last digestion PR, I made peptide N-terminal mod and N-terminal modification localization mutually exclusive.
This incorrect change results in no isobaric quantification labels being added to the peptide which contains the protein terminus. 

#### Changes
- `DigestionProduct.cs`: Ensured correct application and management of protease-associated and terminal modifications. By maintining current overwriting behavior, but ensuring that protein n-term overwrites peptide and not the other way around when applicable. 
- `ModificationLocalization.cs`: "Peptide N-terminal." mods are now valid on ALL N-termini. 
- `TestProteinDigestion.cs`: Updated and added test cases to reflect new terminal modification logic.
- `TestDigestion.cs`: Adjusted tests for expected digestion products and sequences with terminal modifications.
